### PR TITLE
feat(infra): add platform docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,98 @@
+services:
+  gamerbell:
+    image: mattlol85/bell-api:latest
+    container_name: gamerbell
+    restart: unless-stopped
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
+      MONGO_HOST: mongo
+      MONGO_PORT: 27017
+      MONGO_DATABASE: ${MONGO_DATABASE}
+    networks:
+      - fitznet
+      - internal
+    expose:
+      - "8080"
+    labels:
+      caddy: gamerbell.fitznet.doomdns.org
+      caddy.reverse_proxy: "{{upstreams 8080}}"
+      caddy_network: fitznet
+    depends_on:
+      - mongo
+
+  fitz-net-api:
+    image: mattlol85/fitz-net-api:latest
+    container_name: fitz-net-api
+    restart: unless-stopped
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
+      JWT_SECRET: ${JWT_SECRET}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
+      MONGO_HOST: mongo
+      MONGO_PORT: 27017
+      MONGO_DATABASE: ${MONGO_DATABASE}
+    networks:
+      - fitznet
+      - internal
+    expose:
+      - "8080"
+    labels:
+      caddy: api.fitznet.doomdns.org, api.fitznet.org
+      caddy.reverse_proxy: "{{upstreams 8080}}"
+      caddy_network: fitznet
+    depends_on:
+      - mongo
+
+  fitz-net-website:
+    image: mattlol85/fitz-net-website:latest
+    container_name: fitz-net-website
+    restart: unless-stopped
+    networks:
+      - fitznet
+      - internal
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    expose:
+      - "80"
+    labels:
+      caddy: fitznet.org, fitznet.doomdns.org
+      caddy.reverse_proxy: "{{upstreams 80}}"
+      caddy_network: fitznet
+    depends_on:
+      - fitz-net-api
+
+  mongo:
+    image: mongo:4.4
+    container_name: fitz-net-api-mongo
+    restart: unless-stopped
+    environment:
+      MONGO_INITDB_DATABASE: ${MONGO_DATABASE}
+    volumes:
+      - mongo_data:/data/db
+    networks:
+      - internal
+    ports:
+      - "27017:27017"
+
+  caddy:
+    image: lucaslorentz/caddy-docker-proxy:latest
+    container_name: caddy
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - caddy_data:/data
+    networks:
+      - fitznet
+
+volumes:
+  mongo_data:
+  caddy_data:
+
+networks:
+  fitznet:
+    external: true
+  internal:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,10 @@
+# Prerequisites (run once on the host before first deploy):
+#   1. Create the external network:  docker network create fitznet
+#   2. Copy .env.example to .env and fill in secrets
+#
+# Deploy:
+#   docker compose up -d
+
 services:
   gamerbell:
     image: mattlol85/bell-api:latest


### PR DESCRIPTION
## Summary

- Adds a single `docker-compose.yml` at the repo root to bring up the full Fitz-Net platform with one command
- Defines all five services: `caddy`, `fitz-net-website`, `fitz-net-api`, `gamerbell`, `mongo`
- Uses `lucaslorentz/caddy-docker-proxy` — Caddy picks up routing rules from container labels automatically
- Services on the `fitznet` external network are reachable by Caddy; `internal` network is isolated for MongoDB
- Secrets (`JWT_SECRET`, `ENCRYPTION_KEY`, `MONGO_DATABASE`) are injected via `.env` — see `.env.example` (separate PR)

## Test plan

- [ ] Copy `.env.example` to `.env` and fill in secrets
- [ ] Ensure the `fitznet` external Docker network exists (`docker network create fitznet`)
- [ ] `docker compose up -d` — all containers start without errors
- [ ] `docker compose ps` — all services show as running
- [ ] Verify routing: `https://fitznet.org`, `https://api.fitznet.doomdns.org`, `https://gamerbell.fitznet.doomdns.org`

🤖 Generated with [Claude Code](https://claude.com/claude-code)