### PR TITLE
feat(infra): add .env.example and ignore .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Copy this file to .env and fill in the values before running docker-compose.
+# Never commit .env to version control.
+
+# MongoDB
+MONGO_DATABASE=fitznet
+
+# fitz-net-api secrets
+JWT_SECRET=
+ENCRYPTION_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local


### PR DESCRIPTION
## Summary

- Adds `.env.example` documenting the three secrets required by `docker-compose.yml`
- Adds `.env` to `.gitignore` so the real secrets file is never accidentally committed

## Variables

| Variable | Used by | Description |
|---|---|---|
| `MONGO_DATABASE` | `mongo`, `fitz-net-api`, `gamerbell` | MongoDB database name |
| `JWT_SECRET` | `fitz-net-api` | Secret key for signing JWT tokens |
| `ENCRYPTION_KEY` | `fitz-net-api` | Key for the encryption/decryption service |

## Test plan

- [ ] Confirm `.env` does not appear in `git status` after being created locally
- [ ] Confirm `.env.example` is tracked and visible on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)