### PR TITLE
feat(infra): add observability stack — Grafana, Loki, Prometheus, Promtail

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@
 
 [![Product Name Screen Shot][product-screenshot]](https://fitznet.org)
 
-Fitz-Net is a self-hosted, full-stack personal platform running on a home server — exposed to the internet via dynamic DNS. It's a place to build and ship real ideas, backed by real infrastructure: a Proxmox hypervisor, Docker containers, a reverse proxy, and physical ESP32 hardware that talks to the backend over WebSockets.
+Fitz-Net is a self-hosted, full-stack personal platform running on a home server — exposed to the internet via dynamic DNS. It's a place to build and ship real ideas, backed by real infrastructure: a Proxmox hypervisor, Docker containers, a Caddy reverse proxy, physical ESP32 hardware that talks to the backend over WebSockets, and a full observability stack (Grafana, Loki, Prometheus, Promtail, cAdvisor).
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -94,6 +94,15 @@ graph TD
             API["fitz-net-api\nSpring Boot REST"]
             Bell["GamerBell\nWebSocket + OTA"]
             Mongo["MongoDB"]
+
+            subgraph Obs["observability/"]
+                Grafana["Grafana\n:3000"]
+                Prometheus["Prometheus\n:9090"]
+                Loki["Loki\n:3100"]
+                Promtail["Promtail"]
+                CAdvisor["cAdvisor\n:8081"]
+                NodeExp["node-exporter\n:9100"]
+            end
         end
     end
 
@@ -105,6 +114,12 @@ graph TD
     Caddy --> Bell
     API --> Mongo
     ESP32 -->|"wss"| Bell
+
+    Promtail -->|"logs"| Loki
+    CAdvisor -->|"metrics"| Prometheus
+    NodeExp -->|"metrics"| Prometheus
+    Loki --> Grafana
+    Prometheus --> Grafana
 ```
 
 ### Services
@@ -182,6 +197,7 @@ graph LR
 * [![MongoDB][MongoDB]][MongoDB-url]
 * [![Docker][Docker]][Docker-url]
 * [![Caddy][Caddy]][Caddy-url]
+* [![Grafana][Grafana]][Grafana-url]
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -218,6 +234,13 @@ cd GamerBell
 ./gradlew bootRun --args='--spring.profiles.active=dev'
 ```
 
+**Observability stack** — run on the Docker host:
+```sh
+cd observability
+docker compose up -d
+# Grafana UI available at http://<host-ip>:3000  (default login: admin / admin)
+```
+
 See each repo's `.github/agents.md` for full conventions, build commands, and architecture details.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
@@ -232,6 +255,7 @@ See each repo's `.github/agents.md` for full conventions, build commands, and ar
 - [x] ESP32 physical bell button with WebSocket integration (GamerBell + Esp32FitznetBell)
 - [x] OTA firmware updates for ESP32 devices via GitHub Releases
 - [x] Self-hosted on Proxmox + Docker behind Caddy reverse proxy
+- [x] Observability stack — Grafana, Loki, Prometheus, Promtail, cAdvisor, node-exporter
 - [ ] Raspberry Pi remote client with hardware buttons
     - [ ] 3D print enclosure and upload files to GitHub
 
@@ -314,3 +338,6 @@ Project Link: [https://github.com/mattlol85/Fitz-Net](https://github.com/mattlol
 
 [Caddy]: https://img.shields.io/badge/Caddy-1F88C0?style=for-the-badge&logo=caddy&logoColor=white
 [Caddy-url]: https://caddyserver.com/
+
+[Grafana]: https://img.shields.io/badge/Grafana-F46800?style=for-the-badge&logo=grafana&logoColor=white
+[Grafana-url]: https://grafana.com/

--- a/observability/docker-compose.yml
+++ b/observability/docker-compose.yml
@@ -1,0 +1,81 @@
+services:
+  loki:
+    image: grafana/loki:3.6.0
+    container_name: loki
+    command: -config.file=/etc/loki/config.yml
+    volumes:
+      - ./loki/config.yml:/etc/loki/config.yml:ro
+      - loki-data:/loki
+    ports:
+      - "3100:3100"
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:10.4.2
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana-data:/var/lib/grafana
+    restart: unless-stopped
+    depends_on:
+      - loki
+      - prometheus
+
+  promtail:
+    image: grafana/promtail:3.6.0
+    container_name: promtail
+    command: -config.file=/etc/promtail/config.yml
+    volumes:
+      - ./promtail/config.yml:/etc/promtail/config.yml:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    restart: unless-stopped
+    depends_on:
+      - loki
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --web.enable-lifecycle
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus:/etc/prometheus:ro
+      - prometheus-data:/prometheus
+    restart: unless-stopped
+    depends_on:
+      - cadvisor
+      - node-exporter
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:latest
+    container_name: cadvisor
+    ports:
+      - "8081:8080"
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+    restart: unless-stopped
+
+  node-exporter:
+    image: prom/node-exporter:latest
+    container_name: node-exporter
+    ports:
+      - "9100:9100"
+    pid: host
+    command:
+      - --path.rootfs=/host
+    volumes:
+      - /:/host:ro,rslave
+    restart: unless-stopped
+
+volumes:
+  loki-data:
+  grafana-data:
+  prometheus-data:

--- a/observability/loki/config.yml
+++ b/observability/loki/config.yml
@@ -1,0 +1,37 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+ruler:
+  alertmanager_url: http://localhost:9093

--- a/observability/prometheus/prometheus.yml
+++ b/observability/prometheus/prometheus.yml
@@ -1,0 +1,27 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: cadvisor
+    static_configs:
+      - targets: ['cadvisor:8080']
+
+  - job_name: node-exporter
+    static_configs:
+      - targets: ['node-exporter:9100']
+
+  # Spring Boot Actuator — requires micrometer-registry-prometheus in each service
+  - job_name: fitz-net-api
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ['host.docker.internal:8080']
+
+  - job_name: gamerbell
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ['host.docker.internal:8081']

--- a/observability/promtail/config.yml
+++ b/observability/promtail/config.yml
@@ -1,0 +1,23 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    relabel_configs:
+      - source_labels: ['__meta_docker_container_name']
+        regex: '/(.*)'
+        target_label: container
+      - source_labels: ['__meta_docker_container_log_stream']
+        target_label: logstream
+      - source_labels: ['__meta_docker_container_label_com_docker_compose_service']
+        target_label: service


### PR DESCRIPTION
## Summary

Tracks the full observability stack running on the Proxmox Docker host in `observability/`.

## New Files

| File | Purpose |
|------|---------|
| `observability/docker-compose.yml` | Full stack definition (exact config from deploy host) |
| `observability/loki/config.yml` | Loki v13 schema, local filesystem storage |
| `observability/promtail/config.yml` | Docker socket discovery — ships all container logs with `container` and `service` labels |
| `observability/prometheus/prometheus.yml` | Scrapes cAdvisor, node-exporter, and Spring Boot Actuator endpoints |

## Stack Components

| Container | Image | Port | Role |
|-----------|-------|------|------|
| `grafana` | `grafana/grafana:10.4.2` | 3000 | Dashboards — visualises logs + metrics |
| `loki` | `grafana/loki:3.6.0` | 3100 | Log aggregation backend |
| `promtail` | `grafana/promtail:3.6.0` | — | Tails Docker container logs → Loki |
| `prometheus` | `prom/prometheus:latest` | 9090 | Metrics scraping and storage |
| `cadvisor` | `gcr.io/cadvisor/cadvisor:latest` | 8081 | Per-container CPU/mem/net metrics |
| `node-exporter` | `prom/node-exporter:latest` | 9100 | Host OS metrics |

## README Changes

- Updated infrastructure Mermaid diagram to include observability subgraph with data-flow edges (Promtail → Loki, cAdvisor/node-exporter → Prometheus, both → Grafana)
- Added observability to "Built With" (Grafana badge)
- Updated roadmap — observability checked off
- Added `Getting Started` snippet for spinning up the stack

## Usage

```sh
cd observability
docker compose up -d
# Grafana: http://<host-ip>:3000  (admin / admin on first login)
# Add Loki datasource: http://loki:3100
# Add Prometheus datasource: http://prometheus:9090
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)