### PR TITLE
chore(observability): route grafana to logs.fitznet.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ graph TD
             end
 
             subgraph Obs["observability/"]
-                Grafana["Grafana\n:3000"]
+                Grafana["Grafana\nlogs.fitznet.org"]
                 Prometheus["Prometheus\n:9090"]
                 Loki["Loki\n:3100"]
                 Promtail["Promtail"]
@@ -131,6 +131,7 @@ graph TD
     Caddy --> API
     Caddy --> Bell
     Caddy --> Roundcube
+    Caddy --> Grafana
     API --> Mongo
     MailServer --> Roundcube
     ESP32 -->|"wss"| Bell
@@ -358,7 +359,7 @@ docker exec -ti mailserver setup config dkim
 ```sh
 cd observability
 docker compose up -d
-# Grafana UI available at http://<host-ip>:3000  (default login: admin / admin)
+# Grafana UI available at https://logs.fitznet.org (default login: admin / admin)
 ```
 
 See each repo's `.github/agents.md` for full conventions, build commands, and architecture details.  

--- a/observability/docker-compose.yml
+++ b/observability/docker-compose.yml
@@ -8,15 +8,24 @@ services:
       - loki-data:/loki
     ports:
       - "3100:3100"
+    networks:
+      - observability
     restart: unless-stopped
 
   grafana:
     image: grafana/grafana:10.4.2
     container_name: grafana
-    ports:
-      - "3000:3000"
+    expose:
+      - "3000"
     volumes:
       - grafana-data:/var/lib/grafana
+    networks:
+      - observability
+      - fitznet
+    labels:
+      caddy: logs.fitznet.org
+      caddy.reverse_proxy: "{{upstreams 3000}}"
+      caddy_network: fitznet
     restart: unless-stopped
     depends_on:
       - loki
@@ -30,6 +39,8 @@ services:
       - ./promtail/config.yml:/etc/promtail/config.yml:ro
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - observability
     restart: unless-stopped
     depends_on:
       - loki
@@ -46,6 +57,8 @@ services:
     volumes:
       - ./prometheus:/etc/prometheus:ro
       - prometheus-data:/prometheus
+    networks:
+      - observability
     restart: unless-stopped
     depends_on:
       - cadvisor
@@ -61,6 +74,8 @@ services:
       - /var/run:/var/run:ro
       - /sys:/sys:ro
       - /var/lib/docker/:/var/lib/docker:ro
+    networks:
+      - observability
     restart: unless-stopped
 
   node-exporter:
@@ -73,9 +88,17 @@ services:
       - --path.rootfs=/host
     volumes:
       - /:/host:ro,rslave
+    networks:
+      - observability
     restart: unless-stopped
 
 volumes:
   loki-data:
   grafana-data:
   prometheus-data:
+
+networks:
+  observability:
+    driver: bridge
+  fitznet:
+    external: true

--- a/observability/docker-compose.yml
+++ b/observability/docker-compose.yml
@@ -8,8 +8,6 @@ services:
       - loki-data:/loki
     ports:
       - "3100:3100"
-    networks:
-      - observability
     restart: unless-stopped
 
   grafana:
@@ -19,13 +17,13 @@ services:
       - "3000"
     volumes:
       - grafana-data:/var/lib/grafana
-    networks:
-      - observability
-      - fitznet
     labels:
       caddy: logs.fitznet.org
       caddy.reverse_proxy: "{{upstreams 3000}}"
       caddy_network: fitznet
+    networks:
+      - default
+      - fitznet
     restart: unless-stopped
     depends_on:
       - loki
@@ -39,8 +37,6 @@ services:
       - ./promtail/config.yml:/etc/promtail/config.yml:ro
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
-    networks:
-      - observability
     restart: unless-stopped
     depends_on:
       - loki
@@ -57,8 +53,6 @@ services:
     volumes:
       - ./prometheus:/etc/prometheus:ro
       - prometheus-data:/prometheus
-    networks:
-      - observability
     restart: unless-stopped
     depends_on:
       - cadvisor
@@ -74,8 +68,6 @@ services:
       - /var/run:/var/run:ro
       - /sys:/sys:ro
       - /var/lib/docker/:/var/lib/docker:ro
-    networks:
-      - observability
     restart: unless-stopped
 
   node-exporter:
@@ -88,8 +80,6 @@ services:
       - --path.rootfs=/host
     volumes:
       - /:/host:ro,rslave
-    networks:
-      - observability
     restart: unless-stopped
 
 volumes:
@@ -98,7 +88,5 @@ volumes:
   prometheus-data:
 
 networks:
-  observability:
-    driver: bridge
   fitznet:
     external: true


### PR DESCRIPTION
## Summary
- route Grafana through Caddy at logs.fitznet.org
- attach observability services to an internal compose network and attach Grafana to external itznet
- update README architecture + run instructions to reflect the logs domain

## Changes
- observability/docker-compose.yml
  - added caddy labels to Grafana
  - moved Grafana to expose: 3000 (no direct host publish)
  - added observability network for stack services
  - added external itznet network for Grafana/Caddy communication
- README.md
  - updated infrastructure diagram and observability startup note to https://logs.fitznet.org
