### PR TITLE
docs: add Esp32FitznetBell firmware repo to platform docs

### DIFF
--- a/.github/agents.md
+++ b/.github/agents.md
@@ -6,7 +6,7 @@ This repo is the **orchestration hub** for the Fitz-Net platform. It contains Gi
 
 ## Platform Overview
 
-Fitz-Net is a personal full-stack platform consisting of four sibling repositories:
+Fitz-Net is a personal full-stack platform consisting of five sibling repositories:
 
 | Repo | Path | Role | Stack |
 |---|---|---|---|
@@ -14,6 +14,7 @@ Fitz-Net is a personal full-stack platform consisting of four sibling repositori
 | **fitz-net-api** | `../fitz-net-api` | REST API backend | Java 21, Spring Boot 3.4, Gradle, MongoDB |
 | **fitz-net-website** | `../fitz-net-website` | React SPA frontend | React 19, Vite, React Router v7 |
 | **GamerBell** | `../GamerBell` | WebSocket relay + OTA firmware server | Java 21, Spring Boot 3.4, Gradle |
+| **Esp32FitznetBell** | `../Esp32FitznetBell` | ESP32 bell button firmware (talks to GamerBell over WebSocket, OTA-updated) | C++, PlatformIO, Arduino |
 
 For deep development context on each repo, see their individual `.github/agents.md` files.
 
@@ -35,7 +36,8 @@ When building a feature that spans multiple repos:
 2. Define the API contract first (request/response shape) before writing any code
 3. Implement backend (`fitz-net-api`) before frontend (`fitz-net-website`)
 4. For GamerBell/WebSocket changes: update `ButtonEventDto` and the corresponding `WebSocketButton.jsx` in `fitz-net-website` in sync
-5. See `Fitz-Net-Agent-Sandbox/AGENT_INSTRUCTIONS.md` for the full cross-repo workflow and pitfall reference
+5. For ESP32 bell changes: the `Esp32FitznetBell` firmware (`src/main.cpp`) speaks the same WebSocket event schema as GamerBell — keep the press/release payload aligned. Firmware is delivered to devices over the air via GamerBell's `GET /api/firmware/latest`, which pulls `.bin` artifacts from `Esp32FitznetBell` GitHub Releases.
+6. See `Fitz-Net-Agent-Sandbox/AGENT_INSTRUCTIONS.md` for the full cross-repo workflow and pitfall reference
 
 ---
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@ This repo is the **orchestration hub** for the Fitz-Net platform. It contains Gi
 
 ## Platform Overview
 
-Fitz-Net is a personal full-stack platform consisting of four sibling repositories:
+Fitz-Net is a personal full-stack platform consisting of five sibling repositories:
 
 | Repo | Path | Role | Stack |
 |---|---|---|---|
@@ -14,6 +14,7 @@ Fitz-Net is a personal full-stack platform consisting of four sibling repositori
 | **fitz-net-api** | `../fitz-net-api` | REST API backend | Java 21, Spring Boot 3.4, Gradle, MongoDB |
 | **fitz-net-website** | `../fitz-net-website` | React SPA frontend | React 19, Vite, React Router v7 |
 | **GamerBell** | `../GamerBell` | WebSocket relay + OTA firmware server | Java 21, Spring Boot 3.4, Gradle |
+| **Esp32FitznetBell** | `../Esp32FitznetBell` | ESP32 bell button firmware (talks to GamerBell over WebSocket, OTA-updated) | C++, PlatformIO, Arduino |
 
 For deep development context on each repo, see their individual `.github/agents.md` files.
 
@@ -35,7 +36,8 @@ When building a feature that spans multiple repos:
 2. Define the API contract first (request/response shape) before writing any code
 3. Implement backend (`fitz-net-api`) before frontend (`fitz-net-website`)
 4. For GamerBell/WebSocket changes: update `ButtonEventDto` and the corresponding `WebSocketButton.jsx` in `fitz-net-website` in sync
-5. See `Fitz-Net-Agent-Sandbox/AGENT_INSTRUCTIONS.md` for the full cross-repo workflow and pitfall reference
+5. For ESP32 bell changes: the `Esp32FitznetBell` firmware (`src/main.cpp`) speaks the same WebSocket event schema as GamerBell — keep the press/release payload aligned. Firmware is delivered to devices over the air via GamerBell's `GET /api/firmware/latest`, which pulls `.bin` artifacts from `Esp32FitznetBell` GitHub Releases.
+6. See `Fitz-Net-Agent-Sandbox/AGENT_INSTRUCTIONS.md` for the full cross-repo workflow and pitfall reference
 
 ---
 

--- a/Fitz-Net-Agent-Sandbox/AGENT_INSTRUCTIONS.md
+++ b/Fitz-Net-Agent-Sandbox/AGENT_INSTRUCTIONS.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Fitz-Net is a full-stack platform consisting of four independent sibling repositories. This repo (`Fitz-Net`) is the orchestration hub — it holds GitHub Actions workflows and shared agent documentation but contains no application code.
+Fitz-Net is a full-stack platform consisting of five independent sibling repositories. This repo (`Fitz-Net`) is the orchestration hub — it holds GitHub Actions workflows and shared agent documentation but contains no application code.
 
 | Repo | Path | Role | Stack |
 |---|---|---|---|
@@ -10,6 +10,7 @@ Fitz-Net is a full-stack platform consisting of four independent sibling reposit
 | **fitz-net-api** | `../fitz-net-api` | REST API backend | Java 21, Spring Boot 3.4, Gradle, MongoDB |
 | **fitz-net-website** | `../fitz-net-website` | React SPA frontend | React 19, Vite, React Router v7 |
 | **GamerBell** | `../GamerBell` | WebSocket relay + OTA firmware server for ESP32 bells | Java 21, Spring Boot 3.4, Gradle |
+| **Esp32FitznetBell** | `../Esp32FitznetBell` | ESP32 bell button firmware — connects to GamerBell over WebSocket, OTA-updated | C++, PlatformIO, Arduino |
 
 Each repo has its own `.github/agents.md` with deep per-repo conventions. The sections below cover cross-repo feature development.
 
@@ -99,6 +100,33 @@ Spring Boot WebSocket relay that bridges ESP32 button devices with the Fitz-Net 
 cd ../GamerBell
 ./gradlew test
 ./gradlew bootRun --args='--spring.profiles.active=dev'
+```
+
+### Esp32FitznetBell (`Esp32FitznetBell`)
+
+C++ / PlatformIO firmware for the physical ESP32 bell button. It connects to GamerBell over a WebSocket and mirrors button activity on a local OLED screen. New builds are published as GitHub Releases and pushed to devices over the air through GamerBell's firmware endpoint.
+
+| Area | Location | Notes |
+|---|---|---|
+| Firmware entry point | `src/main.cpp` | Setup/loop, WebSocket client, button + OLED logic |
+| Build config | `platformio.ini` | `board = esp32dev`, `framework = arduino`, `lib_deps` |
+| Headers / shared code | `include/`, `lib/` | Project headers and local libraries |
+
+**Hardware:** ESP32 DevKit · 0.96" SSD1306 OLED (I2C: SDA GPIO 21, SCL GPIO 22) · push button on GPIO 13 (internal pull-up).
+
+**Key conventions:**
+- Built with **PlatformIO** (VS Code). Libraries are pulled automatically via `platformio.ini` `lib_deps`: `Adafruit SSD1306`, `Adafruit GFX`, `ArduinoJson`, `WiFiManager`, `links2004/WebSockets`, `FastLED`.
+- WiFi credentials and the user's display name are **not** hardcoded — they're set at first boot via the `FitzNetBell-Setup` WiFiManager captive portal (`192.168.4.1`).
+- The WebSocket payload (press/release events with the user's name) must stay aligned with GamerBell's `ButtonEventDto`. Verify the server IP/port in `src/main.cpp` before flashing.
+- Firmware is delivered OTA via GamerBell `GET /api/firmware/latest`, which serves `.bin` artifacts from this repo's GitHub Releases — bump the version and publish a release to ship an update.
+- Serial monitor baud rate: `115200`. Set `-DENABLE_DIAGNOSTICS=1` in `platformio.ini` for verbose WebSocket/HTTP logs.
+
+**Build & Flash:**
+```bash
+cd ../Esp32FitznetBell
+pio run                 # Compile firmware
+pio run --target upload  # Flash to a connected ESP32 over USB
+pio device monitor       # View serial output (115200 baud)
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@
         <li><a href="#fitz-net-website">fitz-net-website</a></li>
         <li><a href="#fitz-net-api">fitz-net-api</a></li>
         <li><a href="#gamerbell">GamerBell</a></li>
+        <li><a href="#esp32fitznetbell">Esp32FitznetBell</a></li>
         <li><a href="#mail-server">Mail Server</a></li>
       </ul>
     </li>
@@ -270,6 +271,18 @@ Spring Boot WebSocket relay service bridging physical ESP32 button devices with 
 
 ---
 
+### Esp32FitznetBell
+
+**Repo:** [mattlol85/Esp32FitznetBell](https://github.com/mattlol85/Esp32FitznetBell)
+
+C++ / PlatformIO firmware for the physical ESP32 bell button. The device connects to **GamerBell** over a WebSocket to broadcast button press/release events and shows the currently active users on a local 0.96" OLED screen. WiFi credentials and the user's display name are configured at first boot through the `FitzNetBell-Setup` WiFiManager captive portal — nothing is hardcoded. New firmware is published as GitHub Releases and pushed to devices over the air via GamerBell's `GET /api/firmware/latest`.
+
+**Hardware:** ESP32 DevKit · SSD1306 OLED (I2C — SDA GPIO 21, SCL GPIO 22) · push button on GPIO 13.
+
+**Stack:** C++ · PlatformIO · Arduino framework · WebSockets · Adafruit SSD1306/GFX · ArduinoJson · WiFiManager · FastLED
+
+---
+
 ### Mail Server
 
 **Config:** [`Fitz-Net-Agent-Sandbox/mail/`](https://github.com/mattlol85/Fitz-Net-Agent-Sandbox)  
@@ -343,6 +356,15 @@ npm run dev
 ```sh
 cd GamerBell
 ./gradlew bootRun --args='--spring.profiles.active=dev'
+```
+
+**Esp32FitznetBell** — requires [PlatformIO](https://platformio.org/) and an ESP32 board:
+```sh
+cd Esp32FitznetBell
+pio run                 # Compile firmware
+pio run --target upload  # Flash to a connected ESP32 over USB
+pio device monitor       # Serial logs (115200 baud)
+# First boot: connect to the "FitzNetBell-Setup" WiFi AP to set WiFi + display name
 ```
 
 **Mail stack** — run on the Proxmox Docker host:


### PR DESCRIPTION
## Summary

Documents the **[Esp32FitznetBell](https://github.com/mattlol85/Esp32FitznetBell)** repo — the C++/PlatformIO firmware for the physical ESP32 bell button — as a first-class sibling repo across the platform documentation. The firmware connects to **GamerBell** over a WebSocket and is delivered to devices over the air via GamerBell's `GET /api/firmware/latest`.

The repo was already cloned locally at `../Esp32FitznetBell`.

## Changes

- **`README.md`** — added a `### Esp32FitznetBell` entry under Service Details, a PlatformIO build/flash snippet under Getting Started, and a Table of Contents link. (The repos table, architecture diagrams, and roadmap already referenced it.)
- **`.github/agents.md`** & **`.github/copilot-instructions.md`** — added Esp32FitznetBell to the sibling-repo table (now **five** repos) and a cross-repo dev note covering the shared WebSocket event schema and the OTA firmware flow.
- **`Fitz-Net-Agent-Sandbox/AGENT_INSTRUCTIONS.md`** — added it to the repo table and a dedicated *Architecture & Conventions* section (hardware pinout, PlatformIO libs, build/flash commands, OTA notes).

## Notes

Documentation only — no application code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)