### PR TITLE
fix: block actuator at the edge, upgrade + harden Grafana

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,5 +5,11 @@
 MONGO_DATABASE=fitznet
 
 # fitz-net-api secrets
+# JWT_SECRET must be at least 32 bytes - the API refuses to start otherwise
 JWT_SECRET=
 ENCRYPTION_KEY=
+
+# Grafana admin login (observability stack)
+# Compose reads .env from the directory it runs in, so this must also exist in
+# observability/.env (or be exported) when running the observability stack.
+GRAFANA_ADMIN_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -380,9 +380,20 @@ docker exec -ti mailserver setup config dkim
 **Observability stack** — run on the Docker host:
 ```sh
 cd observability
+# Requires GRAFANA_ADMIN_PASSWORD in observability/.env (see .env.example)
 docker compose up -d
-# Grafana UI available at https://logs.fitznet.org (default login: admin / admin)
+# Grafana UI available at https://logs.fitznet.org (login: admin / $GRAFANA_ADMIN_PASSWORD)
+# Existing installs: the env var only applies to a fresh DB - reset the password once with
+#   docker exec grafana grafana cli admin reset-admin-password "$GRAFANA_ADMIN_PASSWORD"
 ```
+
+**Upgrading Grafana across major versions** (DB migrations are one-way):
+```sh
+# 1. Back up the data volume
+docker run --rm -v observability_grafana-data:/data -v $PWD:/backup alpine tar czf /backup/grafana-data-backup.tgz /data
+# 2. Step through majors: 10.x -> 11.6.15 -> 12.4.4, verifying login + dashboards at each step
+```
+Anonymous access and sign-up are disabled via `GF_*` env vars in `observability/docker-compose.yml`; Grafana's own auth (strong password, no anonymous) is the access control for the internet-facing UI.
 
 See each repo's `.github/agents.md` for full conventions, build commands, and architecture details.  
 See [`docs/mail-server.md`](docs/mail-server.md) for the complete mail server setup guide.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,12 @@ services:
       - "8080"
     labels:
       caddy: gamerbell.fitznet.doomdns.org
+      # Block actuator from the internet except health/info (read browser-side by the
+      # website status dashboard). Prometheus scrapes gamerbell:8080 directly over the
+      # internal Docker network, so it is unaffected by this edge block.
+      caddy.@blockedActuator.path: "/actuator /actuator/*"
+      caddy.@blockedActuator.not.path: "/actuator/health /actuator/info"
+      caddy.respond: "@blockedActuator 403"
       caddy.reverse_proxy: "{{upstreams 8080}}"
       caddy_network: fitznet
     depends_on:
@@ -45,6 +51,11 @@ services:
       - "8080"
     labels:
       caddy: api.fitznet.doomdns.org, api.fitznet.org
+      # Same edge block as gamerbell: /actuator/prometheus is permitAll in the app
+      # and must not be readable from the internet; internal scraping bypasses Caddy.
+      caddy.@blockedActuator.path: "/actuator /actuator/*"
+      caddy.@blockedActuator.not.path: "/actuator/health /actuator/info"
+      caddy.respond: "@blockedActuator 403"
       caddy.reverse_proxy: "{{upstreams 8080}}"
       caddy_network: fitznet
     depends_on:

--- a/observability/docker-compose.yml
+++ b/observability/docker-compose.yml
@@ -11,10 +11,18 @@ services:
     restart: unless-stopped
 
   grafana:
-    image: grafana/grafana:10.4.2
+    # Upgrading from 10.4.2? DB migrations are one-way: back up the grafana-data
+    # volume, step through 11.6.15 first, then move to 12.x (see README).
+    image: grafana/grafana:12.4.4
     container_name: grafana
     expose:
       - "3000"
+    environment:
+      # Only applied on first init of a fresh DB; for an existing volume run:
+      #   docker exec grafana grafana cli admin reset-admin-password "$GRAFANA_ADMIN_PASSWORD"
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD}
+      GF_AUTH_ANONYMOUS_ENABLED: "false"
+      GF_USERS_ALLOW_SIGN_UP: "false"
     volumes:
       - grafana-data:/var/lib/grafana
     labels:
@@ -42,7 +50,7 @@ services:
       - loki
 
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v3.12.0
     container_name: prometheus
     command:
       - --config.file=/etc/prometheus/prometheus.yml
@@ -62,7 +70,7 @@ services:
       - node-exporter
 
   cadvisor:
-    image: gcr.io/cadvisor/cadvisor:latest
+    image: gcr.io/cadvisor/cadvisor:v0.55.1
     container_name: cadvisor
     ports:
       - "8081:8080"
@@ -74,7 +82,7 @@ services:
     restart: unless-stopped
 
   node-exporter:
-    image: prom/node-exporter:latest
+    image: prom/node-exporter:v1.11.1
     container_name: node-exporter
     ports:
       - "9100:9100"


### PR DESCRIPTION
## Summary

- **Caddy edge block** (defense layer for mattlol85/GamerBell#21, plus fitz-net-api's equally-exposed `/actuator/prometheus`): both `gamerbell` and `fitz-net-api` services get a named-matcher label so `/actuator/*` returns 403 from the internet, exempting `/actuator/health` and `/actuator/info` (fetched browser-side by the website status dashboard). Prometheus scrapes both apps directly over the internal `fitznet` network and is unaffected.
- **#42** — Grafana bumped from 10.4.2 to a pinned `12.4.4`, with `GF_SECURITY_ADMIN_PASSWORD` (new `GRAFANA_ADMIN_PASSWORD` env var), anonymous access and sign-up disabled. Prometheus/cAdvisor/node-exporter pinned to concrete tags instead of `:latest`. README documents the new login and major-version upgrade procedure.

## Deploy notes (important)

1. **Grafana upgrade is two-step** — DB migrations are one-way. Back up first, then step through 11.6.15 before 12.4.4:
   ```sh
   docker run --rm -v observability_grafana-data:/data -v $PWD:/backup alpine tar czf /backup/grafana-data-backup.tgz /data
   # temporarily set image: grafana/grafana:11.6.15, up -d, verify login/dashboards, then deploy 12.4.4
   ```
2. **Admin password**: `GF_SECURITY_ADMIN_PASSWORD` only applies to a fresh DB. For the existing volume run once:
   `docker exec grafana grafana cli admin reset-admin-password "$GRAFANA_ADMIN_PASSWORD"`
3. Add `GRAFANA_ADMIN_PASSWORD` to `observability/.env` on the host (compose reads `.env` from its own directory).
4. **Verify the generated Caddyfile** after `docker compose up -d` — the `not.path` nested matcher label is per caddy-docker-proxy's documented named-matcher syntax but should be confirmed live: `docker logs caddy` shows the generated config.

## Verification (post-deploy)

```sh
for p in health info; do curl -so /dev/null -w "$p %{http_code}\n" https://gamerbell.fitznet.doomdns.org/actuator/$p; done  # 200 200
for p in prometheus loggers env; do curl -so /dev/null -w "$p %{http_code}\n" https://gamerbell.fitznet.doomdns.org/actuator/$p; done  # 403 403 403
curl -so /dev/null -w '%{http_code}\n' https://api.fitznet.doomdns.org/actuator/prometheus  # 403
curl -s localhost:9090/api/v1/targets | grep -c '"health":"up"'  # all targets still up
# logs.fitznet.org: admin/admin must FAIL; new password works; dashboards + Loki/Prometheus datasources intact
# fitznet.org status dashboard still shows gamerbell + api version/health
```

Fixes #42
Relates to mattlol85/GamerBell#21

🤖 Generated with [Claude Code](https://claude.com/claude-code)